### PR TITLE
Add support for Dec 2022 appinfo format

### DIFF
--- a/VDFparse.Core/VDFFile.cs
+++ b/VDFparse.Core/VDFFile.cs
@@ -13,6 +13,7 @@ public class VDFFile
     public static List<IVDFFileReader> Readers { get; } = new()
     {
         new AppInfoReader(),
+        new AppInfoReaderDec22(),
         new PackageInfoReader(),
         new PackageInfoReaderOld(),
     };

--- a/VDFparse.Core/infoFiles/AppInfo.cs
+++ b/VDFparse.Core/infoFiles/AppInfo.cs
@@ -1,5 +1,41 @@
 namespace VDFparse;
 
+public class AppInfoReaderDec22 : AppInfoReader , IVDFFileReader
+{
+    public new uint Magic { get => 0x07_56_44_28; }
+
+    public new List<Dataset> Read(BinaryReader reader)
+    {
+        var Datasets = new List<Dataset>();
+        while (true)
+        {
+            var id = reader.ReadUInt32();
+            if (id == 0)
+            {
+                return Datasets;
+            }
+
+            Datasets.Add(new AppDatasetDec22
+            {
+                Id = id,
+                Size = reader.ReadUInt32(),
+                InfoState = reader.ReadUInt32(),
+                LastUpdated = DateTimeFromUnixTimestamp(reader.ReadUInt32()),
+                Token = reader.ReadUInt64(),
+                Hash = reader.ReadBytes(20),
+                ChangeNumber = reader.ReadUInt32(),
+                VDFHash = reader.ReadBytes(20),
+                Data = KVParser.Parse(reader),
+            });
+        }
+    }
+    private static DateTime UnixBaseTime { get; } = new DateTime(1970, 1, 1);
+    private static DateTime DateTimeFromUnixTimestamp(uint unixTime)
+    {
+        return UnixBaseTime.AddSeconds(unixTime);
+    }
+}
+
 public class AppInfoReader : IVDFFileReader
 {
     public uint Magic { get => 0x07_56_44_27; }
@@ -28,7 +64,6 @@ public class AppInfoReader : IVDFFileReader
             });
         }
     }
-
     private static DateTime UnixBaseTime { get; } = new DateTime(1970, 1, 1);
     private static DateTime DateTimeFromUnixTimestamp(uint unixTime)
     {
@@ -36,10 +71,14 @@ public class AppInfoReader : IVDFFileReader
     }
 }
 
+public class AppDatasetDec22 : AppDataset
+{
+    public byte[] VDFHash { get; init; } = null!;
+}
+
 public class AppDataset : Dataset
 {
     public uint Size { get; init; }
     public uint InfoState { get; init; }
     public DateTime LastUpdated { get; init; }
-
 }

--- a/VDFparse.Core/infoFiles/AppInfo.cs
+++ b/VDFparse.Core/infoFiles/AppInfo.cs
@@ -1,44 +1,10 @@
 namespace VDFparse;
 
-public class AppInfoReaderDec22 : AppInfoReader , IVDFFileReader
-{
-    public new uint Magic { get => 0x07_56_44_28; }
-
-    public new List<Dataset> Read(BinaryReader reader)
-    {
-        var Datasets = new List<Dataset>();
-        while (true)
-        {
-            var id = reader.ReadUInt32();
-            if (id == 0)
-            {
-                return Datasets;
-            }
-
-            Datasets.Add(new AppDatasetDec22
-            {
-                Id = id,
-                Size = reader.ReadUInt32(),
-                InfoState = reader.ReadUInt32(),
-                LastUpdated = DateTimeFromUnixTimestamp(reader.ReadUInt32()),
-                Token = reader.ReadUInt64(),
-                Hash = reader.ReadBytes(20),
-                ChangeNumber = reader.ReadUInt32(),
-                VDFHash = reader.ReadBytes(20),
-                Data = KVParser.Parse(reader),
-            });
-        }
-    }
-    private static DateTime UnixBaseTime { get; } = new DateTime(1970, 1, 1);
-    private static DateTime DateTimeFromUnixTimestamp(uint unixTime)
-    {
-        return UnixBaseTime.AddSeconds(unixTime);
-    }
-}
 
 public class AppInfoReader : IVDFFileReader
 {
     public uint Magic { get => 0x07_56_44_27; }
+    public static int Version { get => 0; }
 
     public List<Dataset> Read(BinaryReader reader)
     {
@@ -60,6 +26,7 @@ public class AppInfoReader : IVDFFileReader
                 Token = reader.ReadUInt64(),
                 Hash = reader.ReadBytes(20),
                 ChangeNumber = reader.ReadUInt32(),
+                VDFHash = Version == 0 ? null : reader.ReadBytes(20),
                 Data = KVParser.Parse(reader),
             });
         }
@@ -71,9 +38,10 @@ public class AppInfoReader : IVDFFileReader
     }
 }
 
-public class AppDatasetDec22 : AppDataset
+public class AppInfoReaderDec22 : AppInfoReader, IVDFFileReader
 {
-    public byte[] VDFHash { get; init; } = null!;
+    public new uint Magic { get => 0x07_56_44_28; }
+    public static new short Version { get => 1; }
 }
 
 public class AppDataset : Dataset
@@ -81,4 +49,5 @@ public class AppDataset : Dataset
     public uint Size { get; init; }
     public uint InfoState { get; init; }
     public DateTime LastUpdated { get; init; }
+    public byte[]? VDFHash { get; init; } = null!;
 }


### PR DESCRIPTION
Probably a mess, cause I don't know anything about C#.
I did a quick test and it seems to read the new format just fine, while also maintaining the abiliy to read the old format. 🙂

Used the info about the changes from #2 